### PR TITLE
Do not package adb in patch

### DIFF
--- a/.github/scripts/build_zip.ps1
+++ b/.github/scripts/build_zip.ps1
@@ -49,7 +49,6 @@ if (-not $cli) {
 
 Copy-Item -Path "$Workspace/config/config.toml" -Destination $ReleaseZipDir -Force
 Copy-Item -Path "$Workspace/python/main.dist/*" -Destination $BinariesDir -Recurse -Force
-Copy-Item -Path "$Workspace/python/adb_auto_player/binaries/windows/*" -Destination $BinariesDir -Recurse -Force
 
 # Copy everything from "games" except:
 # - .py files
@@ -80,18 +79,28 @@ foreach ($Item in $Items) {
     }
 }
 
-Write-Output "Files collected in ${ReleaseZipDir}:"
-Get-ChildItem -Path $ReleaseZipDir -Recurse
+if (-not $cli) {
+    New-Item -ItemType Directory -Force -Path $PatchDir
+    Copy-Item -Path (Join-Path $ReleaseZipDir "games") -Destination $PatchDir -Recurse -Force
+    Copy-Item -Path $BinariesDir -Destination $PatchDir -Recurse -Force
+    $PatchZipFile = Join-Path $Workspace "Patch_Windows.zip"
+    Compress-Archive -Path "$PatchDir\*" -DestinationPath $PatchZipFile -Force
+    Write-Output "Patch ZIP file created at ${PatchZipFile}"
+}
+
+# We are only shipping static binaries for the full .zip
+# If we ever need to update them we should add a flag to conditionally add them to Patch
+Copy-Item -Path "$Workspace/python/adb_auto_player/binaries/windows/*" -Destination $BinariesDir -Recurse -Force
 
 if (-not $cli) {
     $ZipFile = Join-Path $Workspace "AdbAutoPlayer_Windows.zip"
     Compress-Archive -Path "$ReleaseZipDir\*" -DestinationPath $ZipFile -Force
     Write-Output "ZIP file created at ${ZipFile}"
-    New-Item -ItemType Directory -Force -Path $PatchDir
-    Copy-Item -Path (Join-Path $ReleaseZipDir "games") -Destination $PatchDir -Recurse -Force
-    Copy-Item -Path $BinariesDir -Destination $PatchDir -Recurse -Force
 
-    $PatchZipFile = Join-Path $Workspace "Patch_Windows.zip"
-    Compress-Archive -Path "$PatchDir\*" -DestinationPath $PatchZipFile -Force
-    Write-Output "Patch ZIP file created at ${PatchZipFile}"
 }
+
+
+
+
+Write-Output "Files collected in ${ReleaseZipDir}:"
+Get-ChildItem -Path $ReleaseZipDir -Recurse

--- a/python/adb_auto_player/config_loader.py
+++ b/python/adb_auto_player/config_loader.py
@@ -22,18 +22,15 @@ class ConfigLoader:
     @property
     def games_dir(self) -> Path:
         """Determine and return the games directory."""
-        candidate: Path = self.working_dir / "adb_auto_player" / "games"
-
-        if candidate.exists():
-            games: Path = candidate
-        else:
-            fallback: Path = (
-                self.working_dir.parent.parent / "python" / "adb_auto_player" / "games"
-            )
-            games = fallback if fallback.exists() else candidate
+        candidates: list[Path] = [
+            self.working_dir / "games",  # distributed GUI Context
+            self.working_dir.parent / "games",  # distributed CLI Context
+            self.working_dir / "adb_auto_player" / "games",
+            self.working_dir.parent.parent / "python" / "adb_auto_player" / "games",
+        ]
+        games: Path = next((c for c in candidates if c.exists()), candidates[0])
 
         logging.debug(f"Python games dir: {games}")
-
         return games
 
     @property


### PR DESCRIPTION
- no longer ship adb.exe and related .dlls in patches because if the adb exe is running it blocks the updater.
- resolve games dir in distributed binary