### PR TITLE
Update Default GUI Size

### DIFF
--- a/cmd/wails/main.go
+++ b/cmd/wails/main.go
@@ -45,7 +45,7 @@ func main() {
 
 	err = wails.Run(&options.App{
 		Title:  "AdbAutoPlayer",
-		Width:  1024,
+		Width:  1296,
 		Height: 768,
 		AssetServer: &assetserver.Options{
 			Assets: assets,


### PR DESCRIPTION
- Increase default GUI height to allow all buttons to be visible without scrolling.