### PR TITLE
fix(ravaged-realm): wait for screen animation before checking squads

### DIFF
--- a/src-tauri/src-python/adb_auto_player/games/afk_journey/base.py
+++ b/src-tauri/src-python/adb_auto_player/games/afk_journey/base.py
@@ -566,6 +566,16 @@ class AFKJourneyBase(Navigation, HeroScannerMixin, Game):
                     "battle/power_up.png",
                     "battle/result.png",
                 ]
+            case Mode.RAVAGED_REALM:
+                return [
+                    "arena/done.png",
+                    "next.png",
+                    "battle/victory_rewards.png",
+                    "retry.png",
+                    "navigation/confirm.png",
+                    "battle/power_up.png",
+                    "battle/result.png",
+                ]
             case _:
                 return [
                     "next.png",

--- a/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/ravaged_realm.py
+++ b/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/ravaged_realm.py
@@ -66,6 +66,8 @@ class RavagedRealmMixin(AFKJourneyBase):
             timeout=self.min_timeout,
         )
         self.tap(label)
+        # Wait for the Ravaged Realm screen to fully animate in before proceeding.
+        self.sleep_navigation()
         self.sleep_navigation()
 
     def _try_skip(self) -> bool:
@@ -254,24 +256,20 @@ class RavagedRealmMixin(AFKJourneyBase):
 
             logging.info(f"Checking squad tab {tab_idx}/4 ({faction})...")
             self.tap(tab_point)
-            sleep(2)
 
-            # Verify if the screen successfully switched to this squad's faction
-            faction_icon = self.game_find_template_match(
-                template=f"legend_trials/faction_icon_{faction.lower()}.png",
-                crop_regions=CropRegions(right=0.5, top=0.2, bottom=0.5),
-                threshold=ConfidenceValue("70%"),
-            )
-            if not faction_icon:
-                logging.info(f"Squad {faction} locked or inactive. Skipping.")
-                continue
-
-            battle_btn = self.find_any_template(
-                templates=["battle/battle.png"],
-                threshold=ConfidenceValue("75%"),
-            )
-            if not battle_btn:
-                logging.info(f"Squad {faction} has no attempts available. Skipping.")
+            # Wait for the squad tab animation to finish.
+            # If battle button never appears, the squad is locked or exhausted.
+            try:
+                self.wait_for_template(
+                    "battle/battle.png",
+                    threshold=ConfidenceValue("75%"),
+                    timeout=self.min_timeout,
+                    timeout_message=f"No battle button found for {faction} squad.",
+                )
+            except GameTimeoutError:
+                logging.info(
+                    f"Squad {faction} has no attempts available or is locked. Skipping."
+                )
                 continue
 
             logging.info(f"Squad {faction} active. Executing battle loop...")


### PR DESCRIPTION
- Double sleep_navigation after entering Ravaged Realm to allow the initial screen animation to complete before proceeding
- Replace fixed sleep(2) + faction_icon check with wait_for_template on battle/battle.png so the bot properly waits for each squad tab animation to finish and correctly detects locked/no-attempts squads
- Add Mode.RAVAGED_REALM case to _get_battle_over_templates() to recognize arena/done.png as a battle-over screen