### PR TITLE
Feature/custom routine all modes

### DIFF
--- a/src-tauri/src-python/adb_auto_player/games/afk_journey/base.py
+++ b/src-tauri/src-python/adb_auto_player/games/afk_journey/base.py
@@ -566,6 +566,16 @@ class AFKJourneyBase(Navigation, HeroScannerMixin, Game):
                     "battle/power_up.png",
                     "battle/result.png",
                 ]
+            case Mode.RAVAGED_REALM:
+                return [
+                    "arena/done.png",
+                    "next.png",
+                    "battle/victory_rewards.png",
+                    "retry.png",
+                    "navigation/confirm.png",
+                    "battle/power_up.png",
+                    "battle/result.png",
+                ]
             case _:
                 return [
                     "next.png",

--- a/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/arena.py
+++ b/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/arena.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from adb_auto_player.decorators import register_command
+from adb_auto_player.decorators import register_command, register_custom_routine_choice
 from adb_auto_player.exceptions import GameTimeoutError
 from adb_auto_player.games.afk_journey.base import AFKJourneyBase
 from adb_auto_player.games.afk_journey.gui_category import AFKJCategory
@@ -22,6 +22,7 @@ class ArenaMixin(AFKJourneyBase):
             tooltip="Participate in daily Arena battles automatically",
         ),
     )
+    @register_custom_routine_choice(label="Arena")
     def run_arena(self) -> None:
         """Use Arena attempts."""
         self.start_up(device_streaming=False)

--- a/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/dailies.py
+++ b/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/dailies.py
@@ -4,7 +4,7 @@ import logging
 from abc import ABC
 from time import sleep
 
-from adb_auto_player.decorators import register_command
+from adb_auto_player.decorators import register_command, register_custom_routine_choice
 from adb_auto_player.exceptions import GameTimeoutError
 from adb_auto_player.games.afk_journey.base import AFKJourneyBase
 from adb_auto_player.games.afk_journey.gui_category import AFKJCategory
@@ -37,7 +37,6 @@ class DailiesMixin(AFKJourneyBase, ABC):
         super().__init__()
         self.perform_essence_swap = False
 
-    # TODO should be broken up into components and registered for my custom routine
     @register_command(
         name="Dailies",
         gui=GUIMetadata(
@@ -46,6 +45,7 @@ class DailiesMixin(AFKJourneyBase, ABC):
             tooltip="Complete all daily tasks and collect rewards automatically",
         ),
     )
+    @register_custom_routine_choice(label="Dailies")
     def run_dailies(self) -> None:
         """Complete daily chores."""
         self.start_up(device_streaming=False)

--- a/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/dream_realm.py
+++ b/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/dream_realm.py
@@ -3,7 +3,7 @@
 import logging
 from time import sleep
 
-from adb_auto_player.decorators import register_command
+from adb_auto_player.decorators import register_command, register_custom_routine_choice
 from adb_auto_player.exceptions import GameTimeoutError
 from adb_auto_player.games.afk_journey.base import AFKJourneyBase
 from adb_auto_player.games.afk_journey.gui_category import AFKJCategory
@@ -28,6 +28,7 @@ class DreamRealmMixin(AFKJourneyBase):
             tooltip="Challenge the Dream Realm bosses automatically",
         ),
     )
+    @register_custom_routine_choice(label="Dream Realm")
     def run_dream_realm(self, daily: bool = False) -> None:
         """Use Dream Realm attempts."""
         self.start_up(device_streaming=False)

--- a/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/frostfire_showdown.py
+++ b/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/frostfire_showdown.py
@@ -4,7 +4,7 @@ import logging
 from abc import ABC
 from time import sleep
 
-from adb_auto_player.decorators import register_command
+from adb_auto_player.decorators import register_command, register_custom_routine_choice
 from adb_auto_player.games.afk_journey.base import AFKJourneyBase
 from adb_auto_player.games.afk_journey.gui_category import AFKJCategory
 from adb_auto_player.models import ConfidenceValue
@@ -97,6 +97,7 @@ class FrostfireShowdownMixin(AFKJourneyBase, ABC):
             tooltip="Participate in the Frostfire Showdown event automatically",
         ),
     )
+    @register_custom_routine_choice(label="Frostfire Showdown")
     def attempt_frostfire(self) -> None:
         """Attempt to run Frostfire Showdown Battles."""
         self.start_up()

--- a/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/homestead_helper.py
+++ b/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/homestead_helper.py
@@ -7,7 +7,7 @@ from time import sleep
 from typing import ClassVar
 
 import cv2
-from adb_auto_player.decorators import register_command
+from adb_auto_player.decorators import register_command, register_custom_routine_choice
 from adb_auto_player.exceptions import GameTimeoutError
 from adb_auto_player.games.afk_journey.base import AFKJourneyBase
 from adb_auto_player.games.afk_journey.gui_category import AFKJCategory
@@ -71,6 +71,7 @@ class HomesteadHelperMixin(AFKJourneyBase):
             tooltip="Assist with production and orders in the Homestead automatically",
         ),
     )
+    @register_custom_routine_choice(label="Homestead Orders Helper")
     def navigate_production_buildings_for_crafting(self) -> None:
         """Navigate through kitchen, forge, and alchemy for crafting."""
         self.start_up()

--- a/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/quests.py
+++ b/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/quests.py
@@ -4,7 +4,7 @@ import logging
 from abc import ABC
 from time import sleep
 
-from adb_auto_player.decorators import register_command
+from adb_auto_player.decorators import register_command, register_custom_routine_choice
 from adb_auto_player.games.afk_journey.base import AFKJourneyBase
 from adb_auto_player.games.afk_journey.gui_category import AFKJCategory
 from adb_auto_player.models import ConfidenceValue
@@ -27,6 +27,7 @@ class QuestMixin(AFKJourneyBase, ABC):
             ),
         ),
     )
+    @register_custom_routine_choice(label="Auto-Progress Quests")
     def attempt_quests(self) -> None:
         """Attempt to run quests in quest log."""
         # Basic function to press buttons needed to progress quests, will stop when it

--- a/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/ravaged_realm.py
+++ b/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/ravaged_realm.py
@@ -66,6 +66,8 @@ class RavagedRealmMixin(AFKJourneyBase):
             timeout=self.min_timeout,
         )
         self.tap(label)
+        # Wait for the Ravaged Realm screen to fully animate in before proceeding.
+        self.sleep_navigation()
         self.sleep_navigation()
 
     def _try_skip(self) -> bool:
@@ -254,24 +256,20 @@ class RavagedRealmMixin(AFKJourneyBase):
 
             logging.info(f"Checking squad tab {tab_idx}/4 ({faction})...")
             self.tap(tab_point)
-            sleep(2)
 
-            # Verify if the screen successfully switched to this squad's faction
-            faction_icon = self.game_find_template_match(
-                template=f"legend_trials/faction_icon_{faction.lower()}.png",
-                crop_regions=CropRegions(right=0.5, top=0.2, bottom=0.5),
-                threshold=ConfidenceValue("70%"),
-            )
-            if not faction_icon:
-                logging.info(f"Squad {faction} locked or inactive. Skipping.")
-                continue
-
-            battle_btn = self.find_any_template(
-                templates=["battle/battle.png"],
-                threshold=ConfidenceValue("75%"),
-            )
-            if not battle_btn:
-                logging.info(f"Squad {faction} has no attempts available. Skipping.")
+            # Wait for the squad tab animation to finish.
+            # If battle button never appears, the squad is locked or exhausted.
+            try:
+                self.wait_for_template(
+                    "battle/battle.png",
+                    threshold=ConfidenceValue("75%"),
+                    timeout=self.min_timeout,
+                    timeout_message=f"No battle button found for {faction} squad.",
+                )
+            except GameTimeoutError:
+                logging.info(
+                    f"Squad {faction} has no attempts available or is locked. Skipping."
+                )
                 continue
 
             logging.info(f"Squad {faction} active. Executing battle loop...")

--- a/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/ravaged_realm.py
+++ b/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/ravaged_realm.py
@@ -3,7 +3,7 @@
 import logging
 from time import sleep
 
-from adb_auto_player.decorators import register_command
+from adb_auto_player.decorators import register_command, register_custom_routine_choice
 from adb_auto_player.exceptions import GameActionFailedError, GameTimeoutError
 from adb_auto_player.games.afk_journey.base import AFKJourneyBase
 from adb_auto_player.games.afk_journey.battle_state import Mode
@@ -26,6 +26,7 @@ class RavagedRealmMixin(AFKJourneyBase):
             tooltip="Complete the Ravaged Realm event automatically",
         ),
     )
+    @register_custom_routine_choice(label="Ravaged Realm")
     def run_ravaged_realm(self) -> None:
         """Complete Ravaged Realm."""
         self.battle_state.mode = Mode.RAVAGED_REALM

--- a/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/sunlit_showdown.py
+++ b/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/sunlit_showdown.py
@@ -4,7 +4,7 @@ import logging
 from abc import ABC
 from time import sleep
 
-from adb_auto_player.decorators import register_command
+from adb_auto_player.decorators import register_command, register_custom_routine_choice
 from adb_auto_player.games.afk_journey.base import AFKJourneyBase
 from adb_auto_player.games.afk_journey.gui_category import AFKJCategory
 from adb_auto_player.models import ConfidenceValue
@@ -23,6 +23,7 @@ class SunlitShowdownMixin(AFKJourneyBase, ABC):
             tooltip="Participate in the Sunlit Showdown event automatically",
         ),
     )
+    @register_custom_routine_choice(label="Sunlit Showdown")
     def attempt_sunlit(self) -> None:
         """Attempt to run Sunlit Showdown Battles."""
         self.start_up()


### PR DESCRIPTION
All game modes are now available as Custom Routine steps.

Previously, only 7 options could be selected in the Custom Routine task lists (AFK Stages, Season AFK Stages, Dura's Trials, Season Legend Trial, Arcane Labyrinth, Claim AFK Rewards, Equip new Equipment, Level Up All Heroes).

The following modes have been added:

- Arena
- Dream Realm
- Dailies
- Ravaged Realm
- Sunlit Showdown
- Frostfire Showdown
- Auto-Progress Quests
- Homestead Orders Helper