### PR TITLE
fix(afk_journey): resolve navigation hang on defeat screens and prevent accidental proxy battle requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
 
 - 🎮 **ADB Streaming**: Restored absolute backward compatibility for continuous H264 screen capture on custom emulator configurations (such as BlueStacks 5 running with the combined Vulkan backend) by automatically defaulting to highly resilient chunked stream processing and stripping incompatible runtime codec overrides.
 - ⚔️ **AFK Journey**: Resolved a race condition during **Ravaged Realm** battle prep screen loading by synchronizing detection of both the preparation layout and gold purchase modals simultaneously, guaranteeing seamless automated attempt management and popup interception.
+- ⚔️ **AFK Journey**: Fixed an automated navigation issue where defeat screens matching the "Power Up" header could inadvertently tap the center assist coordinate and leave the application stuck on the "Proxy Battle Request" overlay; the detection logic now reliably attempts to trigger the retry action or gracefully returns to the formation layout.

--- a/src-tauri/src-python/adb_auto_player/games/afk_journey/base.py
+++ b/src-tauri/src-python/adb_auto_player/games/afk_journey/base.py
@@ -690,10 +690,16 @@ class AFKJourneyBase(Navigation, HeroScannerMixin, Game):
                     self._re_enter_battle_for_duras()
                     result = False
                 else:
-                    # TODO should probably just throw an Exception
-                    # I have no idea what this case is used for
-                    # should leave comments in the future
-                    self.tap(Point(x=550, y=1800))
+                    logging.info(f"Lost Battle #{attempt}, retrying")
+                    if retry_btn := self.game_find_template_match(
+                        "retry.png",
+                        threshold=ConfidenceValue("70%"),
+                        crop_regions=CropRegions(top=0.4),
+                    ):
+                        self.tap(retry_btn)
+                    else:
+                        self.press_back_button()
+                    result = False
 
             case "navigation/confirm.png":
                 # TODO should probably just throw an Exception


### PR DESCRIPTION
### Description

This PR fixes an automated navigation bug in AFK Journey modes (such as AFK Stages and Legend Trials) where the bot could inadvertently get stuck on the in-game "Proxy Battle Request" overlay after a stage defeat.

#### Root Cause
When a battle is lost, the game displays the "Power Up" defeat screen. If template recognition for the `retry.png` button intermittently falls below the default confidence threshold, the fallback sequence catches `battle/power_up.png`. Previously, for non-Dura's Trials modes, this triggered a generic tap at the bottom-center coordinate (`Point(x=550, y=1800)`), which directly hits the in-game Proxy Battle Request button and leaves the application hanging on the overlay.

#### Solution & Changes Applied
- **Targeted Retry Search**: Updated the `battle/power_up.png` detection handler to actively search for the `retry.png` button using a slightly relaxed confidence threshold (`70%`) within the expected bottom layout region.
- **Graceful Fallback**: If the retry button is successfully identified, it is tapped to immediately trigger the next attempt. If obscured or missing, the logic executes a standard back button press to return safely to the pre-battle formation selection screen.
- **State Integrity**: Explicitly assigns `result = False` to guarantee robust tracking of failed attempts across multi-formation passes.
- **Documentation**: Added the corresponding entry to `CHANGELOG.md`.
