### PR TITLE
12.9.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
   - Made the battle button interaction more robust by utilizing `_tap_till_template_disappears`.
 - **Daily Quests**:
   - Fixed a logic inversion bug when claiming friend rewards where the script failed to dismiss the confirmation popup on success.
+  - Resolved a runtime `AttributeError` by adding sibling mixins (`ArenaMixin`, `DurasTrialsMixin`, `SeasonLegendTrial`, `AFKStagesMixin`) to the base classes of `DailiesMixin` to restore them to the Method Resolution Order (MRO), and resolved MRO conflicts in tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## [12.9.10] - 2026-06-12
+## [12.9.11] - 2026-06-13
+
+### Features
+
+- **Hero Roster Scanner**:
+  - Refactored paragon lock resolution with a dynamic threshold chain to properly compute and unlock higher Paragon tiers (P1 through P4) from confirmed hero counts.
 
 ### Bug Fixes
 
-- **Daily Quests**:
-  - Fixed remaining instantiation bugs in daily quest runners (Arena, Dura's Trials, Legend Trials, AFK Stages) to correctly call subclass/instance methods on `self` instead of instantiating mixin classes directly.
+- **Dura's Trials**:
+  - Made the battle button interaction more robust by utilizing `_tap_till_template_disappears`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,5 @@
 
 - **Dura's Trials**:
   - Made the battle button interaction more robust by utilizing `_tap_till_template_disappears`.
+- **Daily Quests**:
+  - Fixed a logic inversion bug when claiming friend rewards where the script failed to dismiss the confirmation popup on success.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adb-auto-player"
-version = "12.9.10"
+version = "12.9.11"
 dependencies = [
  "chrono",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 resolver = "2"
 
 [workspace.package]
-version = "12.9.10"
+version = "12.9.11"
 edition = "2021"
 
 

--- a/package.json
+++ b/package.json
@@ -52,5 +52,5 @@
     "tauri": "tauri"
   },
   "type": "module",
-  "version": "12.9.10"
+  "version": "12.9.11"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "workspace"
-version = "12.9.10"
+version = "12.9.11"
 requires-python = ">=3.11"
 dependencies = [
     "pytest-cov>=7.1.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adb-auto-player"
-version = "12.9.10"
+version = "12.9.11"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/pyproject.toml
+++ b/src-tauri/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "adb-auto-player"
-version = "12.9.10"
+version = "12.9.11"
 description = ""
 readme = "README.md"
 authors = [

--- a/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/dailies.py
+++ b/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/dailies.py
@@ -3,7 +3,6 @@
 import logging
 from abc import ABC
 from time import sleep
-from typing import TYPE_CHECKING
 
 from adb_auto_player.decorators import register_command, register_custom_routine_choice
 from adb_auto_player.exceptions import GameTimeoutError
@@ -14,19 +13,16 @@ from adb_auto_player.models.decorators import GUIMetadata
 from adb_auto_player.models.geometry import Point
 from adb_auto_player.models.image_manipulation import CropRegions
 
-if TYPE_CHECKING:
-    pass
+from .afk_stages import AFKStagesMixin
+from .arena import ArenaMixin
+from .duras_trials import DurasTrialsMixin
+from .legend_trial import SeasonLegendTrial
 
 
-class DailiesMixin(AFKJourneyBase, ABC):
+class DailiesMixin(
+    ArenaMixin, DurasTrialsMixin, SeasonLegendTrial, AFKStagesMixin, AFKJourneyBase, ABC
+):
     """Dailies Mixin."""
-
-    if TYPE_CHECKING:
-
-        def run_arena(self) -> None: ...
-        def push_duras_trials(self) -> None: ...
-        def push_legend_trials(self) -> None: ...
-        def push_afk_stages(self, season: bool = False) -> None: ...
 
     def __init__(self) -> None:
         """Initialize Dailies Mixin."""
@@ -370,17 +366,17 @@ class DailiesMixin(AFKJourneyBase, ABC):
         sleep(1)
 
         logging.debug("Click Send & Receive.")
-        if not self._try_wait_and_tap(
+        if self._try_wait_and_tap(
             "dailies/hamburger/send_receive.png",
             timeout_message="Friend rewards already claimed.",
         ):
+            sleep(self.fast_timeout)
+            self.tap(Point(540, 1620))  # Close confirmation
+            sleep(1)
+        else:
             logging.info(f"Friend rewards already claimed. {self.LANG_ERROR}")
-            return
-        sleep(self.fast_timeout)
-        self.tap(Point(540, 1620))  # Close confirmation
-        sleep(1)
 
-        logging.debug("Back.")  # TODO: Create generic back method.
+        logging.debug("Back.")
         back = self.game_find_template_match("back.png")
         self.tap(back) if back else self.press_back_button()
 

--- a/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/duras_trials.py
+++ b/src-tauri/src-python/adb_auto_player/games/afk_journey/mixins/duras_trials.py
@@ -91,8 +91,8 @@ class DurasTrialsMixin(AFKJourneyBase):
                     logging.info("Dura's Trials already cleared")
                     return False
                 case "duras_trials/battle.png":
-                    self.tap(dura_state_result)
-                    sleep(2)
+                    self._tap_till_template_disappears("duras_trials/battle.png")
+                    self.sleep_navigation()
                 case "battle/records.png":
                     # No action needed.
                     pass

--- a/src-tauri/src-python/adb_auto_player/games/afk_journey/services/hero_scanner.py
+++ b/src-tauri/src-python/adb_auto_player/games/afk_journey/services/hero_scanner.py
@@ -29,8 +29,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-WHALE_THRESHOLD = 25
-PARAGON_LOCK_THRESHOLD = 15
+# (qualifying ascensions, heroes needed, tier unlocked)
+_PARAGON_THRESHOLDS: list[tuple[list[str], int, str]] = [
+    (["Supreme+", "Paragon 1", "Paragon 2", "Paragon 3", "Paragon 4"], 25, "Paragon 1"),
+    (["Paragon 1", "Paragon 2", "Paragon 3", "Paragon 4"], 20, "Paragon 2"),
+    (["Paragon 2", "Paragon 3", "Paragon 4"], 15, "Paragon 3"),
+    (["Paragon 3", "Paragon 4"], 15, "Paragon 4"),
+]
+
+_UNCERTAIN_ASCENSIONS = {"Pending S+/P4", "Paragon Locked"}
 
 ASCENSION_OCR_MAP = {
     "C '": "Paragon 1",
@@ -293,7 +300,9 @@ class HeroScanner:
         """
         heroes = full_data.get("heroes", [])
 
-        sup_and_p_count = sum(
+        # Include uncertain heroes in the potential-S+ count to avoid undercounting
+        # when many S+ heroes couldn't be confirmed individually during the scan.
+        potential_sup_count = sum(
             1
             for h in heroes
             if h.get("currentAscension")
@@ -313,39 +322,62 @@ class HeroScanner:
             for h in heroes
         )
 
-        paragon_possible = sup_and_p_count >= WHALE_THRESHOLD
-        is_paragon_unlocked = paragon_possible and (
+        _sup_threshold = _PARAGON_THRESHOLDS[0][1]
+        paragon_globally_possible = potential_sup_count >= _sup_threshold and (
             has_p123 or not global_ascend_available
         )
 
-        self._resolve_pending_heroes(
-            heroes, is_paragon_unlocked, global_ascend_available
-        )
+        confirmed = [
+            h for h in heroes if h.get("currentAscension") not in _UNCERTAIN_ASCENSIONS
+        ]
+        resolved_tier = self._compute_locked_tier(confirmed)
 
-        if not is_paragon_unlocked:
+        self._resolve_pending_heroes(heroes, resolved_tier)
+
+        if not paragon_globally_possible:
             self._downgrade_misread_paragons(heroes)
 
-        self._resolve_locked_heroes(heroes)
+        self._resolve_locked_heroes(heroes, resolved_tier)
 
         with open(self.tracker_file, "w", encoding="utf-8") as f:
             json.dump(full_data, f, indent=4, ensure_ascii=False)
 
-    def _resolve_pending_heroes(
-        self, heroes: list, is_paragon_unlocked: bool, global_ascend_available: bool
-    ) -> None:
+    def _compute_locked_tier(self, confirmed_heroes: list) -> str:
+        """Determine the ascension tier for unresolved heroes from confirmed counts.
+
+        Walks the unlock chain (S+→P1→P2→P3→P4) and returns the highest tier
+        whose requirement is met by the confirmed hero counts.
+
+        Args:
+            confirmed_heroes: Heroes whose ascension is already known (not uncertain).
+
+        Returns:
+            The ascension string all uncertain heroes should receive.
+        """
+        resolved = "Supreme+"
+        for qualifying, threshold, tier in _PARAGON_THRESHOLDS:
+            count = sum(
+                1 for h in confirmed_heroes if h.get("currentAscension") in qualifying
+            )
+            if count >= threshold:
+                resolved = tier
+            else:
+                break
+        return resolved
+
+    def _resolve_pending_heroes(self, heroes: list, resolved_tier: str) -> None:
         pending_heroes = [
             h for h in heroes if h.get("currentAscension") == "Pending S+/P4"
         ]
         if not pending_heroes:
             return
 
-        resolved_pending = "Paragon 4" if is_paragon_unlocked else "Supreme+"
         logger.info(
             f"Resolving {len(pending_heroes)} 'Pending S+/P4' heroes to "
-            f"'{resolved_pending}'."
+            f"'{resolved_tier}'."
         )
         for h in pending_heroes:
-            h["currentAscension"] = resolved_pending
+            h["currentAscension"] = resolved_tier
 
     def _downgrade_misread_paragons(self, heroes: list) -> None:
         misread_paragons = [
@@ -357,29 +389,15 @@ class HeroScanner:
         ]
         if misread_paragons:
             logger.info(
-                f"Paragon tier locked (< {WHALE_THRESHOLD} S+). Downgrading "
+                f"Paragon tier locked (< 25 S+). Downgrading "
                 f"{len(misread_paragons)} misidentified Paragon ranks to 'Supreme+'."
             )
             for h in misread_paragons:
                 h["currentAscension"] = "Supreme+"
 
-    def _resolve_locked_heroes(self, heroes: list) -> None:
-        p1_list = ["Paragon 1", "Paragon 2", "Paragon 3", "Paragon 4", "Paragon Locked"]
-        p2_list = ["Paragon 2", "Paragon 3", "Paragon 4", "Paragon Locked"]
-        sup_list = ["Supreme+", *p1_list]
-
-        sup_count = sum(1 for h in heroes if h.get("currentAscension") in sup_list)
-        p1_count = sum(1 for h in heroes if h.get("currentAscension") in p1_list)
-        p2_count = sum(1 for h in heroes if h.get("currentAscension") in p2_list)
-
-        if sup_count < WHALE_THRESHOLD:
-            resolved_locked = "Supreme+"
-        elif p1_count < PARAGON_LOCK_THRESHOLD:
-            resolved_locked = "Paragon 1"
-        elif p2_count < PARAGON_LOCK_THRESHOLD:
-            resolved_locked = "Paragon 2"
-        else:
-            resolved_locked = "Paragon 3"
+    def _resolve_locked_heroes(self, heroes: list, resolved_tier: str) -> None:
+        # Paragon Locked heroes definitively have an Ascend button — P1 minimum.
+        locked_tier = resolved_tier if "Paragon" in resolved_tier else "Paragon 1"
 
         locked_heroes = [
             h for h in heroes if h.get("currentAscension") == "Paragon Locked"
@@ -387,11 +405,10 @@ class HeroScanner:
         if locked_heroes:
             logger.info(
                 f"Resolving {len(locked_heroes)} 'Paragon Locked' heroes"
-                f" to '{resolved_locked}' "
-                f"(Counts - S+: {sup_count}, P1: {p1_count}, P2: {p2_count})"
+                f" to '{locked_tier}'"
             )
             for h in locked_heroes:
-                h["currentAscension"] = resolved_locked
+                h["currentAscension"] = locked_tier
 
     # ------------------------------------------------------------------
     # JSON persistence helpers

--- a/src-tauri/src-python/tests/games/afk_journey/mixins/test_all_mixins_extended.py
+++ b/src-tauri/src-python/tests/games/afk_journey/mixins/test_all_mixins_extended.py
@@ -493,3 +493,57 @@ def test_scan_guild_activeness():
     assert len(saved_records) == 2
     assert saved_records[0]["Name"] == "BlackFriday"
     assert saved_records[0]["Activeness"] == 1280
+
+
+def test_claim_friend_rewards_send_receive_found():
+    """Cover if-branch: send_receive found → sleep, tap to close, then back."""
+    bot = MockAllAFKJ()
+    with (
+        patch.object(bot, "_try_wait_and_tap", side_effect=[True, True]),
+        patch.object(bot, "press_back_button"),
+        patch("time.sleep"),
+    ):
+        bot._claim_friend_rewards()
+
+
+def test_claim_friend_rewards_already_claimed():
+    """Cover else-branch: send_receive not found → log already claimed, then back."""
+    bot = MockAllAFKJ()
+    with (
+        patch.object(bot, "_try_wait_and_tap", side_effect=[True, False]),
+        patch.object(bot, "press_back_button"),
+        patch("time.sleep"),
+    ):
+        bot._claim_friend_rewards()
+
+
+def test_claim_friend_rewards_back_button_found():
+    """Cover self.tap(back) path when back.png template is found."""
+    bot = MockAllAFKJ()
+    back_match = MagicMock()
+    with (
+        patch.object(bot, "_try_wait_and_tap", side_effect=[True, False]),
+        patch.object(bot, "game_find_template_match", return_value=back_match),
+        patch.object(bot, "tap") as mock_tap,
+        patch("time.sleep"),
+    ):
+        bot._claim_friend_rewards()
+        mock_tap.assert_called()
+
+
+def test_duras_trials_battle_case_coverage():
+    """Cover 'duras_trials/battle.png' case.
+
+    Checks _tap_till_template_disappears and sleep_navigation.
+    """
+    bot = MockAllAFKJ()
+    battle_result = MagicMock()
+    battle_result.template = "duras_trials/battle.png"
+    with (
+        patch.object(bot, "_dura_resolve_state", return_value=battle_result),
+        patch.object(bot, "_tap_till_template_disappears") as mock_tap_till,
+        patch.object(bot, "_handle_battle_screen", return_value=False),
+        patch("time.sleep"),
+    ):
+        bot._handle_dura_screen()
+        mock_tap_till.assert_called_once_with("duras_trials/battle.png")

--- a/src-tauri/src-python/tests/games/afk_journey/mixins/test_all_mixins_extended.py
+++ b/src-tauri/src-python/tests/games/afk_journey/mixins/test_all_mixins_extended.py
@@ -3,13 +3,11 @@ from unittest.mock import MagicMock, mock_open, patch
 
 from adb_auto_player.exceptions import GameTimeoutError
 from adb_auto_player.file_loader.settings_loader import SettingsLoader
-from adb_auto_player.games.afk_journey.mixins.afk_stages import AFKStagesMixin
 from adb_auto_player.games.afk_journey.mixins.arcane_labyrinth import (
     ArcaneLabyrinthMixin,
 )
 from adb_auto_player.games.afk_journey.mixins.assist import AssistMixin
 from adb_auto_player.games.afk_journey.mixins.dailies import DailiesMixin
-from adb_auto_player.games.afk_journey.mixins.duras_trials import DurasTrialsMixin
 from adb_auto_player.games.afk_journey.mixins.frostfire_showdown import (
     FrostfireShowdownMixin,
 )
@@ -30,11 +28,9 @@ from adb_auto_player.models.template_matching import TemplateMatchResult
 
 
 class MockAllAFKJ(
-    AFKStagesMixin,
     ArcaneLabyrinthMixin,
     AssistMixin,
     DailiesMixin,
-    DurasTrialsMixin,
     FrostfireShowdownMixin,
     HomesteadHelperMixin,
     QuestMixin,

--- a/src-tauri/src-python/tests/games/afk_journey/services/test_hero_scanner.py
+++ b/src-tauri/src-python/tests/games/afk_journey/services/test_hero_scanner.py
@@ -11,11 +11,12 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
-from adb_auto_player.games.afk_journey.services.hero_scanner import (
-    PARAGON_LOCK_THRESHOLD,
-    WHALE_THRESHOLD,
-    HeroScanner,
-)
+from adb_auto_player.games.afk_journey.services.hero_scanner import HeroScanner
+
+_SUP_TO_P1 = 25  # S+ heroes needed to unlock P1
+_P1_TO_P2 = 20  # P1 heroes needed to unlock P2
+_P2_TO_P3 = 15  # P2 heroes needed to unlock P3
+_P3_TO_P4 = 15  # P3 heroes needed to unlock P4
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -400,11 +401,11 @@ class TestResolveLockedParagons:
     def _full_data(self, heroes: list[dict]) -> dict:
         return {"heroes": heroes}
 
-    def test_pending_resolved_to_paragon4_when_whale(self, tmp_path):
+    def test_pending_resolved_to_paragon1_when_enough_sup_not_enough_p1(self, tmp_path):
         scanner = _make_scanner()
         scanner.tracker_file = str(tmp_path / "tracker.json")
-        # Build WHALE_THRESHOLD heroes at S+/P-tier + 1 P1
-        heroes = [_make_hero(f"h{i}", "Supreme+") for i in range(WHALE_THRESHOLD - 1)]
+        # 25 S+ unlocks P1, but only 1 P1 confirmed → P2 not unlocked → pending = P1
+        heroes = [_make_hero(f"h{i}", "Supreme+") for i in range(_SUP_TO_P1 - 1)]
         heroes.append(_make_hero("p1hero", "Paragon 1"))
         heroes.append(_make_hero("pending", "Pending S+/P4"))
         full_data = self._full_data(heroes)
@@ -413,9 +414,25 @@ class TestResolveLockedParagons:
         scanner.resolve_locked_paragons(full_data, global_ascend_available=False)
 
         pending = next(h for h in full_data["heroes"] if h["name"] == "pending")
-        assert pending["currentAscension"] == "Paragon 4"
+        assert pending["currentAscension"] == "Paragon 1"
 
-    def test_pending_resolved_to_supreme_plus_when_not_whale(self, tmp_path):
+    def test_pending_resolved_to_paragon2_when_enough_p1_not_enough_p2(self, tmp_path):
+        scanner = _make_scanner()
+        scanner.tracker_file = str(tmp_path / "tracker.json")
+        # 20 P1 unlocks P2, but only 1 P2 confirmed → P3 not unlocked → pending = P2
+        heroes = [_make_hero(f"s{i}", "Supreme+") for i in range(_SUP_TO_P1)]
+        heroes += [_make_hero(f"p1_{i}", "Paragon 1") for i in range(_P1_TO_P2 - 1)]
+        heroes.append(_make_hero("p2hero", "Paragon 2"))
+        heroes.append(_make_hero("pending", "Pending S+/P4"))
+        full_data = self._full_data(heroes)
+        (tmp_path / "tracker.json").write_text(json.dumps(full_data))
+
+        scanner.resolve_locked_paragons(full_data, global_ascend_available=False)
+
+        pending = next(h for h in full_data["heroes"] if h["name"] == "pending")
+        assert pending["currentAscension"] == "Paragon 2"
+
+    def test_pending_resolved_to_supreme_plus_when_not_enough_sup(self, tmp_path):
         scanner = _make_scanner()
         scanner.tracker_file = str(tmp_path / "tracker.json")
         heroes = [_make_hero(f"h{i}", "Supreme+") for i in range(5)]
@@ -428,7 +445,23 @@ class TestResolveLockedParagons:
         pending = next(h for h in full_data["heroes"] if h["name"] == "pending")
         assert pending["currentAscension"] == "Supreme+"
 
-    def test_misread_paragons_downgraded_when_not_whale(self, tmp_path):
+    def test_pending_resolved_to_paragon4_when_all_thresholds_met(self, tmp_path):
+        scanner = _make_scanner()
+        scanner.tracker_file = str(tmp_path / "tracker.json")
+        heroes = [_make_hero(f"s{i}", "Supreme+") for i in range(_SUP_TO_P1)]
+        heroes += [_make_hero(f"p1_{i}", "Paragon 1") for i in range(_P1_TO_P2)]
+        heroes += [_make_hero(f"p2_{i}", "Paragon 2") for i in range(_P2_TO_P3)]
+        heroes += [_make_hero(f"p3_{i}", "Paragon 3") for i in range(_P3_TO_P4)]
+        heroes.append(_make_hero("pending", "Pending S+/P4"))
+        full_data = self._full_data(heroes)
+        (tmp_path / "tracker.json").write_text(json.dumps(full_data))
+
+        scanner.resolve_locked_paragons(full_data, global_ascend_available=False)
+
+        pending = next(h for h in full_data["heroes"] if h["name"] == "pending")
+        assert pending["currentAscension"] == "Paragon 4"
+
+    def test_misread_paragons_downgraded_when_not_enough_sup(self, tmp_path):
         scanner = _make_scanner()
         scanner.tracker_file = str(tmp_path / "tracker.json")
         heroes = [_make_hero("misread", "Paragon 2")]
@@ -441,36 +474,67 @@ class TestResolveLockedParagons:
         assert misread["currentAscension"] == "Supreme+"
 
 
+class TestComputeLockedTier:
+    def test_returns_supreme_plus_when_no_confirmed(self):
+        scanner = _make_scanner()
+        assert scanner._compute_locked_tier([]) == "Supreme+"
+
+    def test_returns_supreme_plus_when_below_p1_threshold(self):
+        scanner = _make_scanner()
+        heroes = [_make_hero(f"h{i}", "Supreme+") for i in range(_SUP_TO_P1 - 1)]
+        assert scanner._compute_locked_tier(heroes) == "Supreme+"
+
+    def test_returns_paragon1_when_enough_sup_not_enough_p1(self):
+        scanner = _make_scanner()
+        heroes = [_make_hero(f"h{i}", "Supreme+") for i in range(_SUP_TO_P1)]
+        assert scanner._compute_locked_tier(heroes) == "Paragon 1"
+
+    def test_returns_paragon2_when_enough_p1_not_enough_p2(self):
+        scanner = _make_scanner()
+        heroes = [_make_hero(f"s{i}", "Supreme+") for i in range(_SUP_TO_P1)]
+        heroes += [_make_hero(f"p1_{i}", "Paragon 1") for i in range(_P1_TO_P2)]
+        assert scanner._compute_locked_tier(heroes) == "Paragon 2"
+
+    def test_returns_paragon3_when_enough_p2_not_enough_p3(self):
+        scanner = _make_scanner()
+        heroes = [_make_hero(f"s{i}", "Supreme+") for i in range(_SUP_TO_P1)]
+        heroes += [_make_hero(f"p1_{i}", "Paragon 1") for i in range(_P1_TO_P2)]
+        heroes += [_make_hero(f"p2_{i}", "Paragon 2") for i in range(_P2_TO_P3)]
+        assert scanner._compute_locked_tier(heroes) == "Paragon 3"
+
+    def test_returns_paragon4_when_all_thresholds_met(self):
+        scanner = _make_scanner()
+        heroes = [_make_hero(f"s{i}", "Supreme+") for i in range(_SUP_TO_P1)]
+        heroes += [_make_hero(f"p1_{i}", "Paragon 1") for i in range(_P1_TO_P2)]
+        heroes += [_make_hero(f"p2_{i}", "Paragon 2") for i in range(_P2_TO_P3)]
+        heroes += [_make_hero(f"p3_{i}", "Paragon 3") for i in range(_P3_TO_P4)]
+        assert scanner._compute_locked_tier(heroes) == "Paragon 4"
+
+    def test_p1_threshold_is_20_not_15(self):
+        scanner = _make_scanner()
+        # 25 S+ + 15 P1 → not enough for P2 (needs 20) → should return P1
+        heroes = [_make_hero(f"s{i}", "Supreme+") for i in range(_SUP_TO_P1)]
+        heroes += [_make_hero(f"p1_{i}", "Paragon 1") for i in range(15)]
+        assert scanner._compute_locked_tier(heroes) == "Paragon 1"
+
+
 class TestResolveLockedHeroes:
-    def test_locked_resolved_to_supreme_plus_when_below_threshold(self):
+    def test_locked_resolved_to_given_tier(self):
         scanner = _make_scanner()
         heroes = [_make_hero("locked", "Paragon Locked")]
-        scanner._resolve_locked_heroes(heroes)
-        assert heroes[0]["currentAscension"] == "Supreme+"
+        scanner._resolve_locked_heroes(heroes, "Paragon 2")
+        assert heroes[0]["currentAscension"] == "Paragon 2"
 
-    def test_locked_resolved_to_paragon1_when_enough_sup(self):
+    def test_locked_forced_to_paragon1_when_tier_is_supreme_plus(self):
         scanner = _make_scanner()
-        heroes = [_make_hero(f"s{i}", "Supreme+") for i in range(WHALE_THRESHOLD)]
-        heroes.append(_make_hero("locked", "Paragon Locked"))
-        scanner._resolve_locked_heroes(heroes)
-        locked = heroes[-1]
-        assert locked["currentAscension"] == "Paragon 1"
-
-    def test_locked_resolved_to_paragon2_when_enough_p1(self):
-        scanner = _make_scanner()
-        heroes = [_make_hero(f"s{i}", "Supreme+") for i in range(WHALE_THRESHOLD)]
-        heroes += [
-            _make_hero(f"p1_{i}", "Paragon 1") for i in range(PARAGON_LOCK_THRESHOLD)
-        ]
-        heroes.append(_make_hero("locked", "Paragon Locked"))
-        scanner._resolve_locked_heroes(heroes)
-        locked = heroes[-1]
-        assert locked["currentAscension"] == "Paragon 2"
+        heroes = [_make_hero("locked", "Paragon Locked")]
+        scanner._resolve_locked_heroes(heroes, "Supreme+")
+        assert heroes[0]["currentAscension"] == "Paragon 1"
 
     def test_no_locked_heroes_does_nothing(self):
         scanner = _make_scanner()
         heroes = [_make_hero("hero1", "Supreme+")]
-        scanner._resolve_locked_heroes(heroes)
+        scanner._resolve_locked_heroes(heroes, "Paragon 1")
         assert heroes[0]["currentAscension"] == "Supreme+"
 
 
@@ -501,19 +565,19 @@ class TestResolvePendingHeroes:
     def test_no_pending_returns_early(self):
         scanner = _make_scanner()
         heroes = [_make_hero("h1", "Supreme+")]
-        scanner._resolve_pending_heroes(heroes, True, False)
+        scanner._resolve_pending_heroes(heroes, "Paragon 1")
         assert heroes[0]["currentAscension"] == "Supreme+"
 
-    def test_resolves_to_paragon4_when_unlocked(self):
+    def test_resolves_to_given_tier(self):
         scanner = _make_scanner()
         heroes = [_make_hero("pending", "Pending S+/P4")]
-        scanner._resolve_pending_heroes(heroes, True, False)
-        assert heroes[0]["currentAscension"] == "Paragon 4"
+        scanner._resolve_pending_heroes(heroes, "Paragon 2")
+        assert heroes[0]["currentAscension"] == "Paragon 2"
 
-    def test_resolves_to_supreme_plus_when_locked(self):
+    def test_resolves_to_supreme_plus(self):
         scanner = _make_scanner()
         heroes = [_make_hero("pending", "Pending S+/P4")]
-        scanner._resolve_pending_heroes(heroes, False, True)
+        scanner._resolve_pending_heroes(heroes, "Supreme+")
         assert heroes[0]["currentAscension"] == "Supreme+"
 
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -47,5 +47,5 @@
     }
   },
   "productName": "AdbAutoPlayer",
-  "version": "12.9.10"
+  "version": "12.9.11"
 }

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ members = [
 
 [[package]]
 name = "adb-auto-player"
-version = "12.9.10"
+version = "12.9.11"
 source = { editable = "src-tauri" }
 dependencies = [
     { name = "adbutils" },
@@ -1204,7 +1204,7 @@ wheels = [
 
 [[package]]
 name = "workspace"
-version = "12.9.10"
+version = "12.9.11"
 source = { virtual = "." }
 dependencies = [
     { name = "onnxruntime" },


### PR DESCRIPTION
# Changelog

## [12.9.11] - 2026-06-13

### Features

- **Hero Roster Scanner**:
  - Refactored paragon lock resolution with a dynamic threshold chain to properly compute and unlock higher Paragon tiers (P1 through P4) from confirmed hero counts.

### Bug Fixes

- **Dura's Trials**:
  - Made the battle button interaction more robust by utilizing `_tap_till_template_disappears`.
- **Daily Quests**:
  - Fixed a logic inversion bug when claiming friend rewards where the script failed to dismiss the confirmation popup on success.
  - Resolved a runtime `AttributeError` by adding sibling mixins (`ArenaMixin`, `DurasTrialsMixin`, `SeasonLegendTrial`, `AFKStagesMixin`) to the base classes of `DailiesMixin` to restore them to the Method Resolution Order (MRO), and resolved MRO conflicts in tests.