### PR TITLE
12.9.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,10 @@
 # Changelog
 
-## [12.9.19] - 2026-07-03
-
-### Features
-
-- **AFK Journey**:
-  - **Homestead**: Full rewrite of the helper. Added support for resource collection at the Mine and automated fulfillment of Requests (orders) using OCR to prioritize high-reward tasks (thanks to **ranidezdev**).
-  - **Custom Routines**: Added support for setting a per-task repeat toggle ("Once" vs "Repeat") directly in the user interface (thanks to **ranidezdev**).
+## [12.9.20] - 2026-07-03
 
 ### Bug Fixes
 
 - **AFK Journey**:
-  - **Supreme Arena**: Added dismissal logic for post-battle/daily reward screens and added a setting to choose which opponent card (Left/Middle/Right) to attack (thanks to **ranidezdev**).
-  - **Quests**: Improved pathing automation by clicking the quest navigation icon, and resolved issues with dialogue boxes and gesture tasks (thanks to **ranidezdev**).
-  - **Labyrinth**: Improved reliability of the "hold to exit" confirmation (thanks to **ranidezdev**).
-  - Fixed Guild Manager Scan crashing with `RapidOCR detection failed: Invalid OCR configuration` after upgrading to `rapidocr>=3.9.0`, which requires `engine_type` and `model_type` to be explicitly set when using custom OCR params.
+  - **Guild Manager Scan**: Fixed RapidOCR silently returning no results due to an invalid `model_type` value (`small`) for the PP-OCRv4/PP-OCRv5 Chinese models; corrected to `mobile`.
+  - **AFK Stages**: Fixed Season AFK Stages getting stuck on the "Are you sure you want to exit the game?" confirmation by reverting Battle Modes navigation to use the current overview instead of forcing navigation to the World view.
+  - **Homestead**: Lowered the match threshold and enabled grayscale matching for Mine building card detection.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adb-auto-player"
-version = "12.9.18"
+version = "12.9.20"
 dependencies = [
  "chrono",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 resolver = "2"
 
 [workspace.package]
-version = "12.9.16"
+version = "12.9.20"
 edition = "2021"
 
 

--- a/package.json
+++ b/package.json
@@ -52,5 +52,5 @@
     "tauri": "tauri"
   },
   "type": "module",
-  "version": "12.9.18"
+  "version": "12.9.20"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "workspace"
-version = "12.9.16"
+version = "12.9.20"
 requires-python = ">=3.11"
 dependencies = [
     "pytest-cov>=7.1.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adb-auto-player"
-version = "12.9.18"
+version = "12.9.20"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/pyproject.toml
+++ b/src-tauri/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "adb-auto-player"
-version = "12.9.19"
+version = "12.9.20"
 description = ""
 readme = "README.md"
 authors = [

--- a/src-tauri/src-python/adb_auto_player/games/afk_journey/navigation.py
+++ b/src-tauri/src-python/adb_auto_player/games/afk_journey/navigation.py
@@ -334,11 +334,7 @@ class Navigation(PopupMessageHandler, ABC):
         attempt = 0
         max_attempts = 3
         while True:
-            # Must navigate to WORLD (not just current overview) because the
-            # Battle Modes button only exists in the world view. Starting from
-            # homestead (e.g. Resonating Hall) and tapping BATTLE_MODES_POINT
-            # would otherwise hit a homestead building instead.
-            self.navigate_to_world()
+            _ = self.navigate_to_current_overview()
             self.sleep_action()
             try:
                 self._navigate_to_battle_modes_screen()

--- a/src-tauri/src-python/adb_auto_player/ocr/rapidocr_backend.py
+++ b/src-tauri/src-python/adb_auto_player/ocr/rapidocr_backend.py
@@ -41,11 +41,11 @@ class RapidOCRBackend(OCRBackend):
                 "Det.engine_type": EngineType.ONNXRUNTIME,
                 "Det.ocr_version": OCRVersion.PPOCRV4,
                 "Det.lang_type": LangDet.CH,
-                "Det.model_type": ModelType.SMALL,
+                "Det.model_type": ModelType.MOBILE,
                 "Rec.engine_type": EngineType.ONNXRUNTIME,
                 "Rec.ocr_version": OCRVersion.PPOCRV5,
                 "Rec.lang_type": LangRec.CH,
-                "Rec.model_type": ModelType.SMALL,
+                "Rec.model_type": ModelType.MOBILE,
             }
         )
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -47,5 +47,5 @@
     }
   },
   "productName": "AdbAutoPlayer",
-  "version": "12.9.18"
+  "version": "12.9.20"
 }

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ members = [
 
 [[package]]
 name = "adb-auto-player"
-version = "12.9.19"
+version = "12.9.20"
 source = { editable = "src-tauri" }
 dependencies = [
     { name = "adbutils" },
@@ -1208,7 +1208,7 @@ wheels = [
 
 [[package]]
 name = "workspace"
-version = "12.9.16"
+version = "12.9.20"
 source = { virtual = "." }
 dependencies = [
     { name = "onnxruntime" },


### PR DESCRIPTION
# Changelog

## [12.9.20] - 2026-07-03

### Bug Fixes

- **AFK Journey**:
  - **Guild Manager Scan**: Fixed RapidOCR silently returning no results due to an invalid `model_type` value (`small`) for the PP-OCRv4/PP-OCRv5 Chinese models; corrected to `mobile`.
  - **AFK Stages**: Fixed Season AFK Stages getting stuck on the "Are you sure you want to exit the game?" confirmation by reverting Battle Modes navigation to use the current overview instead of forcing navigation to the World view.
  - **Homestead**: Lowered the match threshold and enabled grayscale matching for Mine building card detection.