### PR TITLE
release: v12.9.25 - fix multi-display screenshot/input targeting and …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
-## [12.9.24] - 2026-07-23
+## [12.9.25] - 2026-07-28
 
 ### Bug Fixes
 
-- **AFK Journey**:
-  - Improved `_find_date_tabs` logic and hero scanner ROI bounds to self-correct date tabs and log OCR hero readings accurately.
-- **UI**:
-  - Fixed active profile state synchronization during profile deletion in `+layout.svelte`.
+- **Device / AFK Journey**:
+  - Fixed screenshots and taps targeting the wrong virtual display on
+    emulators that expose multiple displays (observed on MuMuPlayer's
+    Android 15 image), which could cause tasks like Dream Realm to loop
+    indefinitely without recognizing the screen.
+- **OCR**:
+  - Fixed an intermittent access-violation crash in the Qwen2-VL GPU
+    OCR backend caused by two conflicting copies of the OpenMP runtime
+    library.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adb-auto-player"
-version = "12.9.24"
+version = "12.9.25"
 dependencies = [
  "chrono",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 resolver = "2"
 
 [workspace.package]
-version = "12.9.24"
+version = "12.9.25"
 edition = "2021"
 
 

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
     "tauri": "tauri"
   },
   "type": "module",
-  "version": "12.9.24"
+  "version": "12.9.25"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "workspace"
-version = "12.9.24"
+version = "12.9.25"
 requires-python = ">=3.11"
 dependencies = [
     "pytest-cov>=7.1.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adb-auto-player"
-version = "12.9.24"
+version = "12.9.25"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/pyproject.toml
+++ b/src-tauri/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "adb-auto-player"
-version = "12.9.24"
+version = "12.9.25"
 description = ""
 readme = "README.md"
 authors = [

--- a/src-tauri/src-python/adb_auto_player/device/adb/adb_controller.py
+++ b/src-tauri/src-python/adb_auto_player/device/adb/adb_controller.py
@@ -20,6 +20,12 @@ class AdbController:
     def __init__(self):
         """Init."""
         self.d = AdbDeviceWrapper.create_from_settings()
+        # Physical display id (for `screencap -d`) and WM logical display id (for
+        # `input -d`) of the display hosting the game, resolved lazily on first use.
+        # See `_resolve_display_ids`.
+        self._screenshot_display_id: str | None = None
+        self._input_display_id: str | None = None
+        self._display_ids_resolved: bool = False
 
     def set_display_size(self, display_size: str) -> None:
         """Set display size.
@@ -95,9 +101,84 @@ class AdbController:
         self.d.shell("wm size reset")
         logging.info(f"Reset Display Size for Device: {self.d.serial}")
 
-    def screenshot(self) -> str | bytes:
-        """Take screenshot."""
-        return self.d.screenshot()
+    def screenshot(self, package_name_prefixes: list[str] | None = None) -> str | bytes:
+        """Take screenshot.
+
+        Args:
+            package_name_prefixes: Prefixes identifying the game's Android package.
+                Used once (result is cached for this controller's lifetime) to pick the
+                right display when the device exposes more than one, e.g. some
+                emulators create a separate virtual display per running app and the
+                unspecified/default display for `screencap` is not guaranteed to be the
+                one actually running the game.
+        """
+        self._ensure_display_ids_resolved(package_name_prefixes or [])
+        return self.d.screenshot(display_id=self._screenshot_display_id)
+
+    def _ensure_display_ids_resolved(self, package_name_prefixes: list[str]) -> None:
+        """Resolve and cache the game's display ids, once, if not already done."""
+        if self._display_ids_resolved:
+            return
+        self._screenshot_display_id, self._input_display_id = self._resolve_display_ids(
+            package_name_prefixes
+        )
+        self._display_ids_resolved = True
+
+    def _resolve_display_ids(
+        self, package_name_prefixes: list[str]
+    ) -> tuple[str | None, str | None]:
+        """Find the display currently hosting the game.
+
+        Only relevant on devices/emulators that expose more than one display; on a
+        normal single-display device this returns (None, None) immediately. Needed
+        because on multi-display devices/emulators (observed on MuMuPlayer's Android
+        15 image) neither `screencap` nor `input` reliably default to the display
+        actually running the game: `screencap` may capture an unrelated idle display,
+        and `input` follows whichever display currently has system input focus, which
+        can drift to a different display (e.g. the home screen) mid-session.
+
+        Returns:
+            tuple[str | None, str | None]: (physical display id for `screencap -d`,
+                WM logical display id for `input -d`), or (None, None) to fall back to
+                adb's defaults.
+        """
+        display_output = self.d.shell("dumpsys display")
+        if not isinstance(display_output, str):
+            return None, None
+
+        # e.g. "displayId=2, uniqueId='local:4619827767814508545'"
+        viewports = re.findall(
+            r"displayId=(\d+), uniqueId='local:(\d+)'", display_output
+        )
+        if len(viewports) <= 1 or not package_name_prefixes:
+            return None, None
+        wm_id_to_physical_id = dict(viewports)
+
+        window_output = self.d.shell("dumpsys window displays")
+        if not isinstance(window_output, str):
+            return None, None
+
+        current_wm_id: str | None = None
+        for line in window_output.splitlines():
+            display_match = re.match(r"\s*Display:\s*mDisplayId=(\d+)", line)
+            if display_match:
+                current_wm_id = display_match.group(1)
+                continue
+            if (
+                current_wm_id is not None
+                and "visible=true" in line
+                and any(prefix in line for prefix in package_name_prefixes)
+            ):
+                physical_id = wm_id_to_physical_id.get(current_wm_id)
+                if physical_id:
+                    logging.info(
+                        "Multiple displays detected, targeting display "
+                        f"{current_wm_id} (physical id {physical_id}) for "
+                        "screenshots and input"
+                    )
+                    return physical_id, current_wm_id
+
+        return None, None
 
     def stop_game(self, package_name: str) -> None:
         """Stop game."""
@@ -137,7 +218,9 @@ class AdbController:
         Args:
             coordinates (Coordinates): Point to click on.
         """
-        self.d.tap(str(coordinates.x), str(coordinates.y))
+        self.d.tap(
+            str(coordinates.x), str(coordinates.y), display_id=self._input_display_id
+        )
 
     def click(
         self,
@@ -148,11 +231,11 @@ class AdbController:
 
     def press_back_button(self) -> None:
         """Presses the back button."""
-        self.d.keyevent("4")  # alternative 111
+        self.d.keyevent("4", display_id=self._input_display_id)  # alternative 111
 
     def press_enter(self) -> None:
         """Press enter button."""
-        self.d.keyevent("66")  # alternative 108
+        self.d.keyevent("66", display_id=self._input_display_id)  # alternative 108
 
     def swipe(
         self,
@@ -173,6 +256,7 @@ class AdbController:
             str(end_point.x),
             str(end_point.y),
             str(int(duration * 1000)),
+            display_id=self._input_display_id,
         )
 
     def hold(
@@ -187,11 +271,16 @@ class AdbController:
 
     def hold_down(self, coordinates: Coordinates) -> None:
         """Press down at the given coordinates."""
-        self.d.shell(f"input motionevent DOWN {coordinates.as_adb_shell_str()}")
+        self.d.shell(self._motion_event_cmd("DOWN", coordinates))
 
     def hold_release(self, coordinates: Coordinates) -> None:
         """Release touch at the given coordinates."""
-        self.d.shell(f"input motionevent UP {coordinates.as_adb_shell_str()}")
+        self.d.shell(self._motion_event_cmd("UP", coordinates))
+
+    def _motion_event_cmd(self, action: str, coordinates: Coordinates) -> str:
+        display_flag = f"-d {self._input_display_id} " if self._input_display_id else ""
+        coords = coordinates.as_adb_shell_str()
+        return f"input {display_flag}motionevent {action} {coords}"
 
     @property
     @register_cache(CacheGroup.ADB)

--- a/src-tauri/src-python/adb_auto_player/device/adb/adb_device.py
+++ b/src-tauri/src-python/adb_auto_player/device/adb/adb_device.py
@@ -50,47 +50,77 @@ class AdbDeviceWrapper:
         return output
 
     @adb_retry
-    def screenshot(self) -> str | bytes:
+    def screenshot(self, display_id: str | None = None) -> str | bytes:
         """Screenshot.
+
+        Args:
+            display_id: Physical display id (as reported by
+                `dumpsys SurfaceFlinger --display-id`) to capture from. Pass None to let
+                adb pick its default display.
 
         Returns:
             str | bytes: Adb screencap response this can be a message too.
         """
-        with self.d.shell("screencap -p", stream=True) as c:
+        cmd = "screencap -p" if display_id is None else f"screencap -p -d {display_id}"
+        with self.d.shell(cmd, stream=True) as c:
             return c.read_until_close(encoding=None)
 
+    @staticmethod
+    def _input_cmdargs(display_id: str | None, *args: str) -> list[str]:
+        """Build an `input` shell command, optionally targeting a specific display.
+
+        Args:
+            display_id: WM logical display id (see `dumpsys window displays`), or None
+                to let Android route the event to whichever display currently has
+                input focus.
+            *args: The `input` subcommand and its arguments, e.g. "tap", x, y.
+        """
+        cmdargs = ["input"]
+        if display_id is not None:
+            cmdargs.extend(["-d", display_id])
+        cmdargs.extend(args)
+        return cmdargs
+
     @adb_retry
-    def tap(self, x: str, y: str) -> None:
+    def tap(self, x: str, y: str, display_id: str | None = None) -> None:
         """Tap.
 
         Args:
             x: x coordinate
             y: y coordinate
+            display_id: WM logical display id to target, or None for the default.
         """
         with self.d.shell(
-            [
-                "input",
-                "tap",
-                x,
-                y,
-            ],
+            self._input_cmdargs(display_id, "tap", x, y),
             timeout=3,  # if the click didn't happen in 3 seconds it's never happening
             stream=True,
         ) as connection:
             connection.read_until_close()
 
     @adb_retry
-    def keyevent(self, key: str) -> None:
+    def keyevent(self, key: str, display_id: str | None = None) -> None:
         """Key event.
 
         Args:
             key: key code
+            display_id: WM logical display id to target, or None for the default.
         """
-        with self.d.shell(["input", "keyevent", key], stream=True) as connection:
+        with self.d.shell(
+            self._input_cmdargs(display_id, "keyevent", key), stream=True
+        ) as connection:
             connection.read_until_close()
 
     @adb_retry
-    def swipe(self, sx: str, sy: str, ex: str, ey: str, duration: str) -> None:
+    def swipe(
+        self,
+        sx: str,
+        sy: str,
+        ex: str,
+        ey: str,
+        duration: str,
+        *,
+        display_id: str | None = None,
+    ) -> None:
         """Swipe from sx, sy to ex, ey over duration ms.
 
         Args:
@@ -99,17 +129,10 @@ class AdbDeviceWrapper:
             ex: end X-coordinate.
             ey: end Y-coordinate.
             duration: Swipe duration in milliseconds.
+            display_id: WM logical display id to target, or None for the default.
         """
         with self.d.shell(
-            [
-                "input",
-                "swipe",
-                sx,
-                sy,
-                ex,
-                ey,
-                duration,
-            ],
+            self._input_cmdargs(display_id, "swipe", sx, sy, ex, ey, duration),
             stream=True,
         ) as connection:
             connection.read_until_close()

--- a/src-tauri/src-python/adb_auto_player/game/_screenshot_mixin.py
+++ b/src-tauri/src-python/adb_auto_player/game/_screenshot_mixin.py
@@ -70,7 +70,7 @@ class _ScreenshotMixin(_GameBase):
         max_retries = 3
         for attempt in range(max_retries):
             try:
-                data = self.device.screenshot()
+                data = self.device.screenshot(self.package_name_prefixes)
                 if isinstance(data, bytes):
                     return self._apply_vertical_offset_to_screenshot(
                         IO.get_bgr_np_array_from_png_bytes(data)

--- a/src-tauri/src-python/adb_auto_player/ocr/qwen2vl_backend.py
+++ b/src-tauri/src-python/adb_auto_player/ocr/qwen2vl_backend.py
@@ -3,6 +3,7 @@
 import importlib.util
 import json
 import logging
+import os
 import re
 import threading
 from typing import Any
@@ -137,6 +138,14 @@ class QwenVLOCRBackend(OCRBackend):
         if self._model_load_failed or not self._is_available:
             return False
         try:
+            # The bundled extras env ships both torch's and paddle's copies of
+            # libiomp5md.dll; transformers' optional-backend probing can load
+            # paddle's after torch's is already resident, and Intel's OpenMP
+            # runtime doesn't tolerate two copies in one process — it has been
+            # observed crashing with STATUS_ACCESS_VIOLATION inside
+            # torch_cpu.dll. Must be set before the first `import torch` below.
+            os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
             import logging as _logging  # noqa: PLC0415
 
             # Silence HTTP and auth noise using each library's own verbosity API.

--- a/src-tauri/src-python/tests/device/adb/test_adb_controller.py
+++ b/src-tauri/src-python/tests/device/adb/test_adb_controller.py
@@ -1,0 +1,117 @@
+"""Tests for `AdbController._resolve_display_ids`.
+
+Covers the multi-display detection used to pick the display that is actually
+running the game, instead of adb's ambiguous defaults. Regression test for:
+some emulators (observed on MuMuPlayer's Android 15 image) expose several
+virtual displays. `screencap` with no `-d` can capture an unrelated idle
+display (e.g. the Android home screen), and `input` (tap/back/swipe) follows
+whichever display currently has system input focus — which can drift to a
+*different* display than the one screenshots are being captured from (e.g.
+input landing on a home-screen icon while the bot's screenshot still shows
+the game). Both cases leave the bot blind or acting on the wrong screen.
+"""
+
+from unittest.mock import MagicMock
+
+from adb_auto_player.device.adb.adb_controller import AdbController
+from adb_auto_player.models.geometry import Point
+
+_DUMPSYS_DISPLAY_SINGLE = """
+  mViewports=[DisplayViewport{displayId=0, uniqueId='local:4619827820427265280'}]
+"""
+
+_DUMPSYS_DISPLAY_MULTI = """
+  mViewports=[DisplayViewport{displayId=0, uniqueId='local:4619827820427265280'}, DisplayViewport{displayId=2, uniqueId='local:4619827767814508545'}, DisplayViewport{displayId=3, uniqueId='local:4619826888814064386'}]
+"""  # noqa: E501
+
+_DUMPSYS_WINDOW_DISPLAYS_MULTI = """
+  Display: mDisplayId=3 (organized)
+  displayId=3
+  Display: mDisplayId=0 (organized)
+  displayId=0
+  Display: mDisplayId=2 (organized)
+  displayId=2
+      * Task{visible=true A=10052:com.farlightgames.igame.gp}
+"""
+
+
+def _make_controller(shell_side_effect) -> tuple[AdbController, MagicMock]:
+    """Build an AdbController with a mocked device wrapper.
+
+    Returns:
+        tuple[AdbController, MagicMock]: The controller, and the mock assigned to
+            its `.d` — kept as its own properly-typed reference so assertions on
+            it (`.assert_called_with`, `.call_count`, ...) don't go through
+            `controller.d`, which the type checker still sees as `AdbDeviceWrapper`.
+    """
+    controller = AdbController.__new__(AdbController)
+    mock_d = MagicMock()
+    mock_d.shell.side_effect = shell_side_effect
+    controller.d = mock_d
+    controller._screenshot_display_id = None
+    controller._input_display_id = None
+    controller._display_ids_resolved = False
+    return controller, mock_d
+
+
+class TestResolveDisplayIds:
+    """Tests for `AdbController._resolve_display_ids`."""
+
+    def test_single_display_returns_none_none(self):
+        controller, _ = _make_controller([_DUMPSYS_DISPLAY_SINGLE])
+        result = controller._resolve_display_ids(["com.farlightgames.igame.gp"])
+        assert result == (None, None)
+
+    def test_multi_display_resolves_physical_and_wm_id_hosting_game(self):
+        controller, _ = _make_controller(
+            [_DUMPSYS_DISPLAY_MULTI, _DUMPSYS_WINDOW_DISPLAYS_MULTI]
+        )
+        result = controller._resolve_display_ids(["com.farlightgames.igame.gp"])
+        assert result == ("4619827767814508545", "2")
+
+    def test_multi_display_no_matching_package_returns_none_none(self):
+        controller, _ = _make_controller(
+            [_DUMPSYS_DISPLAY_MULTI, _DUMPSYS_WINDOW_DISPLAYS_MULTI]
+        )
+        result = controller._resolve_display_ids(["com.other.app"])
+        assert result == (None, None)
+
+    def test_no_package_prefixes_returns_none_none(self):
+        controller, _ = _make_controller([_DUMPSYS_DISPLAY_MULTI])
+        result = controller._resolve_display_ids([])
+        assert result == (None, None)
+
+    def test_screenshot_caches_resolved_display_ids(self):
+        controller, mock_d = _make_controller(
+            [_DUMPSYS_DISPLAY_MULTI, _DUMPSYS_WINDOW_DISPLAYS_MULTI]
+        )
+        mock_d.screenshot.return_value = b"png-bytes"
+
+        first = controller.screenshot(["com.farlightgames.igame.gp"])
+        second = controller.screenshot(["com.farlightgames.igame.gp"])
+
+        assert first == b"png-bytes"
+        assert second == b"png-bytes"
+        # dumpsys is only queried once, screenshot is captured twice.
+        assert mock_d.shell.call_count == 2
+        assert mock_d.screenshot.call_count == 2
+        mock_d.screenshot.assert_called_with(display_id="4619827767814508545")
+        assert controller._input_display_id == "2"
+
+    def test_tap_uses_resolved_input_display_id(self):
+        controller, mock_d = _make_controller(
+            [_DUMPSYS_DISPLAY_MULTI, _DUMPSYS_WINDOW_DISPLAYS_MULTI]
+        )
+        mock_d.screenshot.return_value = b"png-bytes"
+        controller.screenshot(["com.farlightgames.igame.gp"])
+
+        controller.tap(Point(460, 1830))
+
+        mock_d.tap.assert_called_once_with("460", "1830", display_id="2")
+
+    def test_tap_without_prior_resolution_uses_no_display_id(self):
+        controller, mock_d = _make_controller([])
+
+        controller.tap(Point(460, 1830))
+
+        mock_d.tap.assert_called_once_with("460", "1830", display_id=None)

--- a/src-tauri/src-python/tests/games/afk_journey/test_navigation_extended.py
+++ b/src-tauri/src-python/tests/games/afk_journey/test_navigation_extended.py
@@ -19,12 +19,19 @@ class TestNavigationExtended(unittest.TestCase):
     """Extended tests for Navigation class coverage."""
 
     def setUp(self):
-        # Create a concrete instance
+        # Create a concrete instance. Mocks are kept as their own properly-typed
+        # attributes (self.mock_*) rather than read back through self.nav.* —
+        # the type checker still sees self.nav.tap etc. as the real bound method
+        # from Navigation/_InputMixin, not as a MagicMock, once assigned.
         self.nav = MockNavigation.__new__(MockNavigation)
-        self.nav.find_any_template = MagicMock()
-        self.nav.handle_popup_messages = MagicMock()
-        self.nav.press_back_button = MagicMock()
-        self.nav.tap = MagicMock()
+        self.mock_find_any_template = MagicMock()
+        self.mock_handle_popup_messages = MagicMock()
+        self.mock_press_back_button = MagicMock()
+        self.mock_tap = MagicMock()
+        self.nav.find_any_template = self.mock_find_any_template
+        self.nav.handle_popup_messages = self.mock_handle_popup_messages
+        self.nav.press_back_button = self.mock_press_back_button
+        self.nav.tap = self.mock_tap
         self.nav.CENTER_POINT = Point(540, 960)
 
     def test_handle_overview_navigation_world(self):
@@ -34,7 +41,7 @@ class TestNavigationExtended(unittest.TestCase):
             confidence=ConfidenceValue(1.0),
             box=Box(Point(0, 0), 10, 10),
         )
-        self.nav.find_any_template.return_value = match
+        self.mock_find_any_template.return_value = match
 
         result = self.nav._handle_overview_navigation(Overview.WORLD)
         self.assertEqual(result, Overview.WORLD)
@@ -46,13 +53,13 @@ class TestNavigationExtended(unittest.TestCase):
             confidence=ConfidenceValue(1.0),
             box=Box(Point(100, 100), 50, 50),
         )
-        self.nav.find_any_template.return_value = match
+        self.mock_find_any_template.return_value = match
 
         # When we find homestead_enter but want homestead, it should return None
         # as it needs to enter homestead via tap first.
         result = self.nav._handle_overview_navigation(Overview.HOMESTEAD)
         self.assertIsNone(result)
-        self.nav.tap.assert_called_once()
+        self.mock_tap.assert_called_once()
 
     def test_handle_overview_navigation_homestead_world(self):
         """Test homestead world template (entering homestead from world)."""
@@ -61,7 +68,7 @@ class TestNavigationExtended(unittest.TestCase):
             confidence=ConfidenceValue(1.0),
             box=Box(Point(100, 100), 50, 50),
         )
-        self.nav.find_any_template.return_value = match
+        self.mock_find_any_template.return_value = match
 
         result = self.nav._handle_overview_navigation(Overview.HOMESTEAD)
         self.assertEqual(result, Overview.HOMESTEAD)
@@ -73,11 +80,11 @@ class TestNavigationExtended(unittest.TestCase):
             confidence=ConfidenceValue(1.0),
             box=Box(Point(100, 100), 50, 50),
         )
-        self.nav.find_any_template.return_value = match
+        self.mock_find_any_template.return_value = match
 
         result = self.nav._handle_overview_navigation(Overview.WORLD)
         self.assertIsNone(result)
-        self.nav.tap.assert_called_once_with(self.nav.CENTER_POINT)
+        self.mock_tap.assert_called_once_with(self.nav.CENTER_POINT)
 
     def test_handle_overview_navigation_confirm(self):
         """Test confirm template."""
@@ -86,12 +93,12 @@ class TestNavigationExtended(unittest.TestCase):
             confidence=ConfidenceValue(1.0),
             box=Box(Point(100, 100), 50, 50),
         )
-        self.nav.find_any_template.return_value = match
-        self.nav.handle_popup_messages.return_value = False
+        self.mock_find_any_template.return_value = match
+        self.mock_handle_popup_messages.return_value = False
 
         result = self.nav._handle_overview_navigation(Overview.WORLD)
         self.assertIsNone(result)
-        self.nav.tap.assert_called_once_with(match)
+        self.mock_tap.assert_called_once_with(match)
 
     def test_handle_overview_navigation_dotdotdot(self):
         """Test dotdotdot template."""
@@ -100,31 +107,31 @@ class TestNavigationExtended(unittest.TestCase):
             confidence=ConfidenceValue(1.0),
             box=Box(Point(100, 100), 50, 50),
         )
-        self.nav.find_any_template.return_value = match
+        self.mock_find_any_template.return_value = match
 
         result = self.nav._handle_overview_navigation(Overview.WORLD)
         self.assertIsNone(result)
-        self.nav.press_back_button.assert_called_once()
+        self.mock_press_back_button.assert_called_once()
 
     def test_handle_overview_navigation_popup_handling(self):
         """Test that popup handling prevents hitting Back button."""
-        self.nav.find_any_template.return_value = None
-        self.nav.handle_popup_messages.return_value = True
+        self.mock_find_any_template.return_value = None
+        self.mock_handle_popup_messages.return_value = True
 
         with patch("time.sleep", return_value=None):
             result = self.nav._handle_overview_navigation(Overview.WORLD)
             self.assertIsNone(result)
-            self.nav.handle_popup_messages.assert_called_once()
+            self.mock_handle_popup_messages.assert_called_once()
 
     def test_handle_overview_navigation_back_button_fallback(self):
         """Test that Back button is hit if no template and no popup."""
-        self.nav.find_any_template.return_value = None
-        self.nav.handle_popup_messages.return_value = False
+        self.mock_find_any_template.return_value = None
+        self.mock_handle_popup_messages.return_value = False
 
         with patch("time.sleep", return_value=None):
             result = self.nav._handle_overview_navigation(Overview.WORLD)
             self.assertIsNone(result)
-            self.nav.press_back_button.assert_called_once()
+            self.mock_press_back_button.assert_called_once()
 
     def test_handle_overview_navigation_arcane_labyrinth(self):
         """Test arcane labyrinth crest selection."""
@@ -133,12 +140,12 @@ class TestNavigationExtended(unittest.TestCase):
             confidence=ConfidenceValue(1.0),
             box=Box(Point(100, 100), 50, 50),
         )
-        self.nav.find_any_template.return_value = match
+        self.mock_find_any_template.return_value = match
 
         result = self.nav._handle_overview_navigation(Overview.WORLD)
         self.assertIsNone(result)
         # Should call tap twice (crest and confirm/result)
-        self.assertEqual(self.nav.tap.call_count, 2)
+        self.assertEqual(self.mock_tap.call_count, 2)
 
     def test_handle_overview_navigation_homestead_world_entering(self):
         """Test homestead world template when we want world."""
@@ -147,12 +154,12 @@ class TestNavigationExtended(unittest.TestCase):
             confidence=ConfidenceValue(1.0),
             box=Box(Point(100, 100), 50, 50),
         )
-        self.nav.find_any_template.return_value = match
+        self.mock_find_any_template.return_value = match
 
         # If we want WORLD but are looking at the 'world' button in homestead
         result = self.nav._handle_overview_navigation(Overview.WORLD)
         self.assertIsNone(result)
-        self.nav.tap.assert_called_once_with(match)
+        self.mock_tap.assert_called_once_with(match)
 
     def test_handle_overview_navigation_homestead_enter_world(self):
         """Test homestead enter template when we want world."""
@@ -161,7 +168,7 @@ class TestNavigationExtended(unittest.TestCase):
             confidence=ConfidenceValue(1.0),
             box=Box(Point(100, 100), 50, 50),
         )
-        self.nav.find_any_template.return_value = match
+        self.mock_find_any_template.return_value = match
 
         # If we want WORLD and find homestead_enter, it means we are in WORLD
         result = self.nav._handle_overview_navigation(Overview.WORLD)

--- a/src-tauri/src-python/tests/ocr/test_qwen2vl_backend.py
+++ b/src-tauri/src-python/tests/ocr/test_qwen2vl_backend.py
@@ -3,8 +3,10 @@
 Covers:
 - _download_model_if_needed: partial-download detection via dual-file cache check
 - _init_model: OSError from from_pretrained triggers force re-download and retry
+- _init_model: KMP_DUPLICATE_LIB_OK is set before torch is imported
 """
 
+import os
 from unittest.mock import MagicMock, PropertyMock, call, patch
 
 from adb_auto_player.ocr.qwen2vl_backend import QwenVLOCRBackend
@@ -147,3 +149,82 @@ class TestInitModel:
 
         assert result is False
         assert backend._model_load_failed is True
+
+
+class TestKmpDuplicateLibWorkaround:
+    """Regression test for the torch_cpu.dll access-violation crash.
+
+    The bundled extras env ships both torch's and paddle's copies of
+    libiomp5md.dll; transformers' optional-backend probing can load paddle's
+    after torch's is already resident, and Intel's OpenMP runtime doesn't
+    tolerate two copies in one process. `KMP_DUPLICATE_LIB_OK=TRUE` must be
+    set before the first `import torch`.
+    """
+
+    def test_init_model_sets_kmp_duplicate_lib_ok(self, monkeypatch):
+        monkeypatch.delenv("KMP_DUPLICATE_LIB_OK", raising=False)
+        backend = QwenVLOCRBackend()
+
+        mock_proc_cls = MagicMock()
+        mock_model_cls = MagicMock()
+        mock_model_cls.from_pretrained.return_value = MagicMock()
+        sys_mocks = {
+            "torch": MagicMock(
+                cuda=MagicMock(is_available=MagicMock(return_value=False)),
+                backends=MagicMock(
+                    mps=MagicMock(is_available=MagicMock(return_value=False))
+                ),
+            ),
+            "transformers": MagicMock(
+                Qwen2VLProcessor=mock_proc_cls,
+                Qwen2VLForConditionalGeneration=mock_model_cls,
+            ),
+        }
+
+        with (
+            patch.dict("sys.modules", sys_mocks),
+            patch.object(
+                type(backend),
+                "_is_available",
+                new_callable=PropertyMock,
+                return_value=True,
+            ),
+            patch.object(backend, "_download_model_if_needed"),
+        ):
+            backend._init_model()
+
+        assert os.environ.get("KMP_DUPLICATE_LIB_OK") == "TRUE"
+
+    def test_does_not_override_an_existing_value(self, monkeypatch):
+        """A user-set value (e.g. "FALSE" to keep the safety check) is respected."""
+        monkeypatch.setenv("KMP_DUPLICATE_LIB_OK", "FALSE")
+        backend = QwenVLOCRBackend()
+
+        mock_proc_cls = MagicMock()
+        mock_proc_cls.from_pretrained.side_effect = OSError("boom")
+        sys_mocks = {
+            "torch": MagicMock(
+                cuda=MagicMock(is_available=MagicMock(return_value=False)),
+                backends=MagicMock(
+                    mps=MagicMock(is_available=MagicMock(return_value=False))
+                ),
+            ),
+            "transformers": MagicMock(
+                Qwen2VLProcessor=mock_proc_cls,
+                Qwen2VLForConditionalGeneration=MagicMock(),
+            ),
+        }
+
+        with (
+            patch.dict("sys.modules", sys_mocks),
+            patch.object(
+                type(backend),
+                "_is_available",
+                new_callable=PropertyMock,
+                return_value=True,
+            ),
+            patch.object(backend, "_download_model_if_needed"),
+        ):
+            backend._init_model()
+
+        assert os.environ.get("KMP_DUPLICATE_LIB_OK") == "FALSE"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -47,5 +47,5 @@
     }
   },
   "productName": "AdbAutoPlayer",
-  "version": "12.9.24"
+  "version": "12.9.25"
 }

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ members = [
 
 [[package]]
 name = "adb-auto-player"
-version = "12.9.24"
+version = "12.9.25"
 source = { editable = "src-tauri" }
 dependencies = [
     { name = "adbutils" },
@@ -1205,7 +1205,7 @@ wheels = [
 
 [[package]]
 name = "workspace"
-version = "12.9.24"
+version = "12.9.25"
 source = { virtual = "." }
 dependencies = [
     { name = "onnxruntime" },


### PR DESCRIPTION
…Qwen2-VL crash

- Device/AFK Journey: screenshots and input (tap/back/swipe) now explicitly target the display actually running the game on emulators that expose multiple virtual displays (observed on MuMuPlayer's Android 15 image). Previously screencap could capture an unrelated idle display while input followed drifting system focus, causing tasks like Dream Realm to loop indefinitely without recognizing the screen.
- OCR: set KMP_DUPLICATE_LIB_OK=TRUE before the Qwen2-VL backend's first torch import, working around an intermittent STATUS_ACCESS_VIOLATION crash in torch_cpu.dll caused by duplicate OpenMP runtime copies (torch + paddle) in the bundled extras environment.
- Fixed a pre-existing ty type-check failure in test_navigation_extended.py (Mock attributes read back through a statically-typed path).