### PR TITLE
12.9.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 ### Bug Fixes
 
 - **Device / AFK Journey**:
-  - Fixed screenshots and taps targeting the wrong virtual display on
-    emulators that expose multiple displays (observed on MuMuPlayer's
-    Android 15 image), which could cause tasks like Dream Realm to loop
-    indefinitely without recognizing the screen.
+  - Fixed screenshots, taps, and the device-streaming (`screenrecord`)
+    capture path all targeting the wrong virtual display on emulators
+    that expose multiple displays (observed on MuMuPlayer's Android 15
+    image), which could cause tasks to loop indefinitely without
+    recognizing the screen, or occasionally act on an unrelated app.
 - **OCR**:
   - Fixed an intermittent access-violation crash in the Qwen2-VL GPU
     OCR backend caused by two conflicting copies of the OpenMP runtime

--- a/src-tauri/src-python/adb_auto_player/device/adb/adb_controller.py
+++ b/src-tauri/src-python/adb_auto_player/device/adb/adb_controller.py
@@ -115,6 +115,30 @@ class AdbController:
         self._ensure_display_ids_resolved(package_name_prefixes or [])
         return self.d.screenshot(display_id=self._screenshot_display_id)
 
+    @property
+    def screenshot_display_id(self) -> str | None:
+        """Physical display id resolved by `resolve_display_targeting`, if any.
+
+        Used by `DeviceStream` to pass `screenrecord --display-id`, so streamed
+        frames come from the same display `screenshot()` and `tap()`/etc. target.
+        """
+        return self._screenshot_display_id
+
+    def resolve_display_targeting(self, package_name_prefixes: list[str]) -> None:
+        """Resolve and cache display ids up front, before streaming may start.
+
+        `screenshot()` also resolves lazily on first call, but `DeviceStream`
+        captures frames independently via `screenrecord` and never calls
+        `screenshot()` — so on devices with multiple displays, calling this once
+        during game startup (before `DeviceStream` is created) ensures streamed
+        frames, screenshots, and input all agree on which display is the game's,
+        instead of only screenshots/input being fixed when streaming is off.
+
+        Args:
+            package_name_prefixes: Prefixes identifying the game's Android package.
+        """
+        self._ensure_display_ids_resolved(package_name_prefixes)
+
     def _ensure_display_ids_resolved(self, package_name_prefixes: list[str]) -> None:
         """Resolve and cache the game's display ids, once, if not already done."""
         if self._display_ids_resolved:

--- a/src-tauri/src-python/adb_auto_player/device/adb/device_stream.py
+++ b/src-tauri/src-python/adb_auto_player/device/adb/device_stream.py
@@ -190,17 +190,26 @@ class DeviceStream:
 
     def _handle_stream(self) -> None:
         """Generic stream handler."""
+        # Keep the streamed display in sync with screenshot()/tap() on devices
+        # that expose more than one virtual display (see
+        # AdbController.resolve_display_targeting) — otherwise `screenrecord`
+        # defaults to "the primary display", which is not guaranteed to be the
+        # one actually running the game.
+        display_id = self.controller.screenshot_display_id
+        display_args = [f"--display-id {display_id}"] if display_id else []
+
+        parts = ["screenrecord", "--output-format=h264"]
         if self._is_bluestacks:
-            base_cmd = "screenrecord --output-format=h264"
+            parts.extend(display_args)
         else:
             try:
                 res = self.controller.get_display_info().resolution
-                size_str = f"--size {res.width}x{res.height}"
+                parts.append(f"--size {res.width}x{res.height}")
             except Exception:
-                size_str = ""
-            base_cmd = (
-                f"screenrecord --output-format=h264 {size_str} --bit-rate 2000000"
-            ).strip()
+                pass
+            parts.extend(display_args)
+            parts.append("--bit-rate 2000000")
+        base_cmd = " ".join(parts)
 
         cmdargs = (
             f"{base_cmd} --time-limit=1 -" if self._use_time_limit else f"{base_cmd} -"

--- a/src-tauri/src-python/adb_auto_player/game/_lifecycle_mixin.py
+++ b/src-tauri/src-python/adb_auto_player/game/_lifecycle_mixin.py
@@ -23,6 +23,7 @@ class _LifecycleMixin(_GameBase):
         """
         self._set_device_resolution()
         self._check_requirements()
+        self.device.resolve_display_targeting(self.package_name_prefixes)
         self._start_device_streaming(device_streaming=device_streaming)
         self._check_screenshot_matches_display_resolution(device_streaming_check=False)
 


### PR DESCRIPTION
# Changelog

## [12.9.25] - 2026-07-28

### Bug Fixes

- **Device / AFK Journey**:
  - Fixed screenshots, taps, and the device-streaming (`screenrecord`)
    capture path all targeting the wrong virtual display on emulators
    that expose multiple displays (observed on MuMuPlayer's Android 15
    image), which could cause tasks to loop indefinitely without
    recognizing the screen, or occasionally act on an unrelated app.
- **OCR**:
  - Fixed an intermittent access-violation crash in the Qwen2-VL GPU
    OCR backend caused by two conflicting copies of the OpenMP runtime
    library.